### PR TITLE
Runc create: mount, devfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
@@ -25,10 +25,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.35"
+name = "ansi_term"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "arrayvec"
@@ -49,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "d3340571769500ddef1e94b45055fabed6b08a881269b7570c830b8f32ef84ef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -104,7 +113,7 @@ dependencies = [
  "dockerfile-parser",
  "env_logger",
  "fehler 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
+ "futures 0.3.8",
  "itertools",
  "libc",
  "log",
@@ -122,12 +131,35 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
 dependencies = [
  "byteorder",
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
 ]
 
 [[package]]
@@ -159,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -171,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.4.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byte-tools"
@@ -189,21 +221,24 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+
+[[package]]
+name = "cexpr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -232,6 +267,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f54d78e30b388d4815220c8dd03fea5656b6c6d32adb59e89061552a102f8da1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "colored"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,10 +304,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+name = "common_lib"
+version = "0.1.0"
 
 [[package]]
 name = "core-foundation"
@@ -275,12 +334,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
  "cfg-if 1.0.0",
- "const_fn",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -289,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -369,9 +427,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.26"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -384,9 +442,9 @@ checksum = "2ec878a5d2f3b6e9eaee72373dd23414cfc7d353104741471bec712ef241a66e"
 
 [[package]]
 name = "env_logger"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
  "humantime",
@@ -496,9 +554,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
@@ -517,40 +575,30 @@ dependencies = [
 [[package]]
 name = "futures"
 version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+source = "git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator#192f8e36e5d36edd24aa3d0d25411186417e6fc8"
 dependencies = [
- "futures-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-executor 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.8",
+ "futures-core 0.3.8",
+ "futures-executor 0.3.8",
+ "futures-io 0.3.8",
+ "futures-sink 0.3.8",
+ "futures-task 0.3.8",
+ "futures-util 0.3.8",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.8"
-source = "git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator#192f8e36e5d36edd24aa3d0d25411186417e6fc8"
-dependencies = [
- "futures-channel 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-core 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-executor 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-io 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-sink 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-task 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-util 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
 dependencies = [
- "futures-core 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.13",
+ "futures-core 0.3.13",
+ "futures-executor 0.3.13",
+ "futures-io 0.3.13",
+ "futures-sink 0.3.13",
+ "futures-task 0.3.13",
+ "futures-util 0.3.13",
 ]
 
 [[package]]
@@ -558,47 +606,51 @@ name = "futures-channel"
 version = "0.3.8"
 source = "git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator#192f8e36e5d36edd24aa3d0d25411186417e6fc8"
 dependencies = [
- "futures-core 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-sink 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
+ "futures-core 0.3.8",
+ "futures-sink 0.3.8",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+dependencies = [
+ "futures-core 0.3.13",
+ "futures-sink 0.3.13",
 ]
 
 [[package]]
 name = "futures-core"
 version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+source = "git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator#192f8e36e5d36edd24aa3d0d25411186417e6fc8"
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
-source = "git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator#192f8e36e5d36edd24aa3d0d25411186417e6fc8"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
-dependencies = [
- "futures-core 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
 name = "futures-executor"
 version = "0.3.8"
 source = "git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator#192f8e36e5d36edd24aa3d0d25411186417e6fc8"
 dependencies = [
- "futures-core 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-task 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-util 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
+ "futures-core 0.3.8",
+ "futures-task 0.3.8",
+ "futures-util 0.3.8",
 ]
 
 [[package]]
-name = "futures-io"
-version = "0.3.8"
+name = "futures-executor"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+dependencies = [
+ "futures-core 0.3.13",
+ "futures-task 0.3.13",
+ "futures-util 0.3.13",
+]
 
 [[package]]
 name = "futures-io"
@@ -606,16 +658,10 @@ version = "0.3.8"
 source = "git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator#192f8e36e5d36edd24aa3d0d25411186417e6fc8"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.8"
+name = "futures-io"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-macro"
@@ -629,10 +675,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.8"
+name = "futures-macro"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -640,13 +692,10 @@ version = "0.3.8"
 source = "git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator#192f8e36e5d36edd24aa3d0d25411186417e6fc8"
 
 [[package]]
-name = "futures-task"
-version = "0.3.8"
+name = "futures-sink"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
-dependencies = [
- "once_cell",
-]
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
 
 [[package]]
 name = "futures-task"
@@ -655,21 +704,26 @@ source = "git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "futures-task"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
 name = "futures-util"
 version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+source = "git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator#192f8e36e5d36edd24aa3d0d25411186417e6fc8"
 dependencies = [
- "futures-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-macro 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.8",
+ "futures-core 0.3.8",
+ "futures-io 0.3.8",
+ "futures-macro 0.3.8",
+ "futures-sink 0.3.8",
+ "futures-task 0.3.8",
  "memchr",
- "pin-project 1.0.2",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -678,15 +732,16 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
-source = "git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator#192f8e36e5d36edd24aa3d0d25411186417e6fc8"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
- "futures-channel 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-core 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-io 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-macro 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-sink 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
- "futures-task 0.3.8 (git+https://github.com/akhramov/futures-rs?branch=fix/add-derive-clone-to-with-combinator)",
+ "futures-channel 0.3.13",
+ "futures-core 0.3.13",
+ "futures-io 0.3.13",
+ "futures-macro 0.3.13",
+ "futures-sink 0.3.13",
+ "futures-task 0.3.13",
  "memchr",
  "pin-project-lite",
  "pin-utils",
@@ -706,22 +761,33 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -731,23 +797,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
-name = "h2"
+name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "h2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
- "futures-core 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.13",
+ "futures-sink 0.3.13",
+ "futures-util 0.3.13",
  "http",
  "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -758,35 +829,35 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -797,15 +868,15 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "http",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
 
 [[package]]
 name = "httpdate"
@@ -821,21 +892,21 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
 dependencies = [
- "bytes 1.0.1",
- "futures-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "futures-channel 0.3.13",
+ "futures-core 0.3.13",
+ "futures-util 0.3.13",
  "h2",
  "http",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.2",
+ "pin-project",
  "socket2",
  "tokio",
  "tower-service",
@@ -849,7 +920,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "hyper",
  "native-tls",
  "tokio",
@@ -858,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -869,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -893,6 +964,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
+name = "ipnetwork"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c3eaab3ac0ede60ffa41add21970a7df7d91772c03383aac6c2c3d53cc716b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jail"
@@ -926,11 +1006,27 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.46"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "knast"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "baustelle",
+ "common_lib",
+ "fehler 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jail",
+ "libc",
+ "nix 0.20.0",
+ "serde_json",
+ "tempfile",
+ "test_helpers",
 ]
 
 [[package]]
@@ -940,23 +1036,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.4"
+name = "lazycell"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+
+[[package]]
+name = "libloading"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -975,11 +1087,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1001,6 +1113,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,9 +1139,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -1027,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
 dependencies = [
  "libc",
  "log",
@@ -1060,7 +1182,7 @@ dependencies = [
  "httparse",
  "lazy_static",
  "log",
- "rand",
+ "rand 0.7.3",
  "regex",
  "serde_json",
  "serde_urlencoded 0.6.1",
@@ -1068,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1089,10 +1211,13 @@ name = "netzwerk"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bindgen",
+ "common_lib",
  "fehler 1.0.0 (git+https://github.com/withoutboats/fehler)",
+ "ipnetwork",
  "jail",
  "libc",
- "nix 0.17.0",
+ "nix 0.20.0",
  "test_helpers",
 ]
 
@@ -1120,6 +1245,18 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
+]
+
+[[package]]
+name = "nix"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
 ]
 
 [[package]]
@@ -1185,9 +1322,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -1197,9 +1334,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openssl"
-version = "0.10.31"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d008f51b1acffa0d3450a68606e6a51c123012edaacb0f4e1426bd978869187"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1217,9 +1354,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.59"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
  "autocfg",
  "cc",
@@ -1241,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -1252,6 +1389,12 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -1304,38 +1447,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal 0.4.27",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
-dependencies = [
- "pin-project-internal 1.0.2",
+ "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1344,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -1398,9 +1521,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1412,10 +1535,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "procedural_macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1426,11 +1558,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1440,7 +1584,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1449,7 +1603,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -1458,7 +1621,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1477,15 +1649,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1504,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "registratur"
@@ -1516,7 +1691,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "fehler 1.0.0 (git+https://github.com/withoutboats/fehler)",
- "futures 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.13",
  "hex",
  "log",
  "nom",
@@ -1540,15 +1715,15 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
+checksum = "0460542b551950620a3648c6aa23318ac6b3cd779114bd873209e6e8b5eb1c34"
 dependencies = [
  "base64",
- "bytes 1.0.1",
+ "bytes",
  "encoding_rs",
- "futures-core 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.13",
+ "futures-util 0.3.13",
  "http",
  "http-body",
  "hyper",
@@ -1575,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.19"
+version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",
@@ -1593,6 +1768,12 @@ name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "ryu"
@@ -1627,9 +1808,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
+checksum = "2dfd318104249865096c8da1dfabf09ddbb6d0330ea176812a62ec75e40c4166"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1640,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
+checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1650,18 +1831,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1670,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1705,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd2af560da3c1fdc02cb80965289254fc35dff869810061e2d8290ee48848ae"
+checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -1728,10 +1909,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.2.2"
+name = "shlex"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
 ]
@@ -1760,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "snafu"
@@ -1787,13 +1974,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi",
 ]
 
@@ -1823,6 +2009,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
 name = "strum"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.54"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
+checksum = "ed22b90a0e734a23a7610f4283ac9e5acfb96cbb30dfefa540d66f866f1c09c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1890,13 +2082,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand",
+ "rand 0.8.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -1915,36 +2107,49 @@ dependencies = [
 name = "test_helpers"
 version = "0.1.0"
 dependencies = [
+ "bincode",
+ "jail",
+ "memmap",
  "mockito",
+ "nix 0.17.0",
+ "procedural_macros",
  "serde",
  "serde_yaml",
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.0.1"
+name = "textwrap"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "lazy_static",
+ "unicode-width",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1957,12 +2162,12 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6714d663090b6b0acb0fa85841c6d66233d150cdb2602c8f9b8abb03370beb3f"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
 dependencies = [
  "autocfg",
- "bytes 1.0.1",
+ "bytes",
  "libc",
  "memchr",
  "mio",
@@ -1977,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2002,9 +2207,9 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
 dependencies = [
- "bytes 1.0.1",
- "futures-core 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "futures-core 0.3.13",
+ "futures-sink 0.3.13",
  "log",
  "pin-project-lite",
  "tokio",
@@ -2012,15 +2217,15 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.22"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -2034,16 +2239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
-dependencies = [
- "pin-project 0.4.27",
- "tracing",
 ]
 
 [[package]]
@@ -2075,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]
@@ -2087,6 +2282,12 @@ name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
@@ -2102,9 +2303,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2123,11 +2324,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "rand",
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -2135,6 +2336,12 @@ name = "vcpkg"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -2177,15 +2384,15 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.69"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -2195,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.69"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2210,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.19"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
+checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2222,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.69"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2232,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.69"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2245,15 +2452,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.69"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.46"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
+checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2265,6 +2472,15 @@ version = "0.1.0"
 dependencies = [
  "baustelle",
  "tokio",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ tokio = { version = "1.1.1", features = ["full"] }
 [workspace]
 members = [
     "baustelle",
+    "common_lib",
+    "knast",
     "netzwerk",
     "registratur",
     "storage",

--- a/baustelle/src/containerfile.rs
+++ b/baustelle/src/containerfile.rs
@@ -51,7 +51,6 @@ impl<'a, T: StorageEngine> Builder<'a, T> {
         let container_uuid = format!("{}", Uuid::new_v4());
         let container_folder =
             storage.folder().join("containers").join(&container_uuid);
-
         fs::create_dir_all(&container_folder)?;
 
         Self {

--- a/baustelle/src/lib.rs
+++ b/baustelle/src/lib.rs
@@ -1,5 +1,5 @@
 mod fetcher;
-mod runtime_config;
+pub mod runtime_config;
 mod storage;
 mod unpacker;
 

--- a/baustelle/src/runtime_config.rs
+++ b/baustelle/src/runtime_config.rs
@@ -31,7 +31,8 @@ pub struct Mount {
     pub destination: String,
     pub source: Option<String>,
     pub options: Option<Vec<String>>,
-    pub r#type: Option<String>,
+    // TODO (doc): diverges from OCI
+    pub r#type: String,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/common_lib/Cargo.toml
+++ b/common_lib/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "common_lib"
+version = "0.1.0"
+authors = ["Artem Khramov <akhramov@pm.me>"]
+edition = "2018"
+
+[dependencies]

--- a/common_lib/Cargo.toml~
+++ b/common_lib/Cargo.toml~
@@ -1,0 +1,9 @@
+[package]
+name = "common_lib"
+version = "0.1.0"
+authors = ["Artem Khramov <akhramov@pm.me>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/common_lib/src/lib.rs
+++ b/common_lib/src/lib.rs
@@ -1,0 +1,21 @@
+pub trait AsSignedBytes {
+    fn as_signed_bytes(&self) -> &[i8] {
+        let bytes = unsafe { self.bytes().align_to() };
+
+        bytes.1
+    }
+
+    fn bytes(&self) -> &[u8];
+}
+
+impl AsSignedBytes for &str {
+    fn bytes(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl AsSignedBytes for Vec<u8> {
+    fn bytes(&self) -> &[u8] {
+        self.as_slice()
+    }
+}

--- a/common_lib/src/lib.rs~
+++ b/common_lib/src/lib.rs~
@@ -1,0 +1,15 @@
+pub trait AsSignedBytes {
+    fn as_signed_bytes(&self) -> &[i8] {
+        let bytes = unsafe { self.bytes().align_to() };
+
+        bytes.1
+    }
+
+    fn bytes(&self) -> &[u8];
+}
+
+impl AsSignedBytes for &str {
+    fn bytes(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}

--- a/knast/Cargo.toml
+++ b/knast/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "knast"
+version = "0.1.0"
+authors = ["Artem Khramov <akhramov@pm.me>"]
+edition = "2018"
+
+[dependencies]
+anyhow = "1"
+baustelle = { path = "../baustelle" }
+common_lib = { path = "../common_lib" }
+fehler = "1"
+jail = { git = "https://github.com/fubarnetes/libjail-rs", branch = "dev" }
+libc = "0.2.71"
+nix = "0.20.0"
+serde_json = "1"
+
+[dev-dependencies]
+test_helpers = { path = "../test_helpers" }
+tempfile = "3.1.0"

--- a/knast/src/filesystem.rs
+++ b/knast/src/filesystem.rs
@@ -1,0 +1,154 @@
+/// Handles mounting and unmounting of filesystems.
+/// Some filesystems require additional actions on mount, i.e. devfs nodes
+/// need to be hidden using the rule subsystem, and so on.
+mod devfs;
+mod mount;
+
+use std::{convert::AsRef, path::Path};
+
+use anyhow::Error;
+
+use baustelle::runtime_config::Mount;
+
+pub trait Mountable {
+    #[fehler::throws]
+    fn mount(&self) {
+        mount::mount(
+            self.kind(),
+            self.source(),
+            self.destination(),
+            self.options().iter().map(|x| x as &dyn AsRef<str>),
+        )?;
+
+        self.post_mount_hooks()?;
+    }
+
+    #[fehler::throws]
+    fn unmount(&self) {
+        mount::unmount(&self.destination())?;
+    }
+
+    #[fehler::throws]
+    fn post_mount_hooks(&self);
+
+    fn kind(&self) -> &String;
+    fn source(&self) -> &String;
+    fn destination(&self) -> &String;
+    fn options(&self) -> Vec<String>;
+}
+
+impl Mountable for Mount {
+    fn kind(&self) -> &String {
+        &self.r#type
+    }
+
+    fn source(&self) -> &String {
+        if let Some(source) = &self.source {
+            return &source;
+        }
+
+        self.kind()
+    }
+
+    fn destination(&self) -> &String {
+        &self.destination
+    }
+
+    fn options(&self) -> Vec<String> {
+        self.options.clone().unwrap_or_else(|| vec![])
+    }
+
+    #[fehler::throws]
+    fn post_mount_hooks(&self) {
+        if self.r#type == "devfs" {
+            prepare_devfs(&self.destination)?;
+        }
+    }
+}
+
+/// There's no FreeBSD spec yet, so follow Linux config as possible
+/// https://github.com/opencontainers/runtime-spec/blob/1c3f411f041711bbeecf35ff7e93461ea6789220/config-linux.md#default-devices
+#[fehler::throws]
+fn prepare_devfs(path: impl AsRef<Path>) {
+    use devfs::{apply, Operation};
+
+    const DEFAULT_DEVICES: [&str; 9] = [
+        "null", "zero", "full", "random", "urandom", "tty", "console", "pts",
+        "pts/*",
+    ];
+
+    apply(&path, Operation::HideAll)?;
+
+    for device in &DEFAULT_DEVICES {
+        apply(&path, Operation::Unhide(device))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use super::*;
+
+    #[test]
+    fn test_mounting_nullfs() {
+        let source = tempfile::tempdir().unwrap();
+        let destination = tempfile::tempdir().unwrap();
+
+        let dest = destination.path().to_str().unwrap().into();
+        let src = source.path().to_str().unwrap().into();
+
+        let mount = Mount {
+            destination: dest,
+            source: Some(src),
+            options: None,
+            r#type: "nullfs".into(),
+        };
+
+        mount.mount().expect("failed to mount nullfs");
+
+        let mount_output = Command::new("mount")
+            .output()
+            .expect("Failed to execute mount");
+
+        let output_string = String::from_utf8(mount_output.stdout).unwrap();
+
+        assert!(output_string.contains(&format!(
+            "{} on {} (nullfs",
+            source.path().display(),
+            destination.path().display()
+        )));
+
+        mount.unmount().expect("failed to unmount nullfs");
+    }
+
+    #[test]
+    fn test_mounting_devfs() {
+        let destination = tempfile::tempdir().unwrap();
+
+        let dest = destination.path().to_str().unwrap().into();
+
+        let mount = Mount {
+            destination: dest,
+            source: None,
+            options: None,
+            r#type: "devfs".into(),
+        };
+
+        mount.mount().expect("failed to mount devfs");
+
+        let entries = std::fs::read_dir(destination.path())
+            .expect("failed to read the mounted directory")
+            .map(|res| res.map(|e| e.file_name()))
+            .collect::<Result<Vec<_>, std::io::Error>>()
+            .expect("failed to read a filename in the mounted directory");
+
+        mount.unmount().expect("failed to unmount devfs");
+        assert_eq!(
+            entries,
+            vec![
+                "random", "urandom", "console", "full", "null", "zero", "pts"
+            ]
+        );
+    }
+}

--- a/knast/src/filesystem/devfs.rs
+++ b/knast/src/filesystem/devfs.rs
@@ -1,0 +1,123 @@
+/// During OCI runtime creation, we need to mount directories, in
+/// particular /dev. However, giving the container access to all device
+/// nodes is dangerous. The idiomatic tool for this is devfs control
+/// facilities, which allows us to dynamically hide & unhide device nodes
+/// from the mounted subsystem.
+/// This module replicates devfs(8) behavior to hide devfs nodes from the jail.
+use std::{
+    convert::AsRef, fs::File, io::Error as StdError, mem,
+    os::unix::io::AsRawFd, path::Path,
+};
+
+use anyhow::{anyhow, Error};
+use common_lib::AsSignedBytes;
+use libc::{c_char, c_int, gid_t, ioctl, mode_t, uid_t};
+
+const MAGIC: u32 = 0xdb0a087a;
+const DRA_BACTS: c_int = 0x1;
+const DRB_HIDE: c_int = 0x1;
+const DRB_UNHIDE: c_int = 0x2;
+const DRC_PATHPTRN: c_int = 0x2;
+const DEVFSIO_RAPPLY: u64 = 0x80ec4402;
+
+#[repr(C)]
+struct DevfsRule {
+    magic: u32,
+    id: u32,
+    icond: c_int,
+    dswflags: c_int,
+    pathptrn: [c_char; 200],
+    iacts: c_int,
+    bacts: c_int,
+    uid: uid_t,
+    gid: gid_t,
+    mode: mode_t,
+    incset: u32,
+}
+
+pub enum Operation<'a> {
+    HideAll,
+    Unhide(&'a str),
+}
+
+#[fehler::throws]
+pub fn apply(path: impl AsRef<Path>, operation: Operation) {
+    let file = File::open(path.as_ref())?;
+    let mut rule: DevfsRule = unsafe { mem::zeroed() };
+    rule.magic = MAGIC;
+    rule.iacts = DRA_BACTS;
+
+    match operation {
+        Operation::HideAll => {
+            rule.bacts = DRB_HIDE;
+        }
+        Operation::Unhide(node) => {
+            rule.bacts = DRB_UNHIDE;
+            rule.icond = DRC_PATHPTRN;
+            rule.pathptrn[0..node.len()]
+                .copy_from_slice(node.as_signed_bytes());
+        }
+    }
+
+    if unsafe { ioctl(file.as_raw_fd(), DEVFSIO_RAPPLY, &rule) } < 0 {
+        fehler::throw!(anyhow!(
+            "devfs rule: ioctl(DEVFSIO_RAPPLY) failed: {}",
+            StdError::last_os_error()
+        ))
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::filesystem::mount::{mount, unmount};
+
+    struct MountedDirectory<'a> {
+        path: &'a Path,
+    }
+
+    impl<'a> MountedDirectory<'a> {
+        fn new(path: &'a Path) -> Self {
+            mount(&"devfs", &"devfs", &path, std::iter::empty())
+                .expect("failed to mount directory");
+
+            Self { path }
+        }
+    }
+
+    impl<'a> Drop for MountedDirectory<'a> {
+        fn drop(&mut self) {
+            unmount(&self.path)
+                .expect("failed to unmount directory");
+        }
+    }
+
+    #[test]
+    fn test_device_unhide() {
+        let tmpdir = tempfile::tempdir().unwrap();
+
+        let _directory = MountedDirectory::new(tmpdir.path());
+
+        assert!(
+            tmpdir.path().join("null").exists(),
+            "/dev/null must be present"
+        );
+
+        apply(tmpdir.path(), Operation::HideAll)
+            .expect("Failed to hide all nodes");
+
+        assert!(
+            !tmpdir.path().join("null").exists(),
+            "hide all hides /dev/null"
+        );
+
+        apply(tmpdir.path(), Operation::Unhide("null"))
+            .expect("Failed to unhide /dev/null");
+
+        assert!(
+            tmpdir.path().join("null").exists(),
+            "unhide(null) unhides /dev/null"
+        );
+    }
+}

--- a/knast/src/filesystem/devfs.rs~
+++ b/knast/src/filesystem/devfs.rs~
@@ -1,0 +1,123 @@
+/// During OCI runtime creation, we need to mount directories, in
+/// particular /dev. However, giving the container access to all device
+/// nodes is dangerous. The idiomatic tool for this is devfs control
+/// facilities, which allows us to dynamically hide & unhide device nodes
+/// from the mounted subsystem.
+/// This module replicates devfs(8) behavior to hide devfs nodes from the jail.
+use std::{
+    convert::AsRef, fs::File, io::Error as StdError, mem,
+    os::unix::io::AsRawFd, path::Path,
+};
+
+use anyhow::{anyhow, Error};
+use common_lib::AsSignedBytes;
+use libc::{c_char, c_int, gid_t, ioctl, mode_t, uid_t};
+
+const MAGIC: u32 = 0xdb0a087a;
+const DRA_BACTS: c_int = 0x1;
+const DRB_HIDE: c_int = 0x1;
+const DRB_UNHIDE: c_int = 0x2;
+const DRC_PATHPTRN: c_int = 0x2;
+const DEVFSIO_RAPPLY: u64 = 0x80ec4402;
+
+#[repr(C)]
+struct DevfsRule {
+    magic: u32,
+    id: u32,
+    icond: c_int,
+    dswflags: c_int,
+    pathptrn: [c_char; 200],
+    iacts: c_int,
+    bacts: c_int,
+    uid: uid_t,
+    gid: gid_t,
+    mode: mode_t,
+    incset: u32,
+}
+
+pub enum Operation<'a> {
+    HideAll,
+    Unhide(&'a str),
+}
+
+#[fehler::throws]
+pub fn apply(path: impl AsRef<Path>, operation: Operation) {
+    let file = File::open(path.as_ref())?;
+    let mut rule: DevfsRule = unsafe { mem::zeroed() };
+    rule.magic = MAGIC;
+    rule.iacts = DRA_BACTS;
+
+    match operation {
+        Operation::HideAll => {
+            rule.bacts = DRB_HIDE;
+        }
+        Operation::Unhide(node) => {
+            rule.bacts = DRB_UNHIDE;
+            rule.icond = DRC_PATHPTRN;
+            rule.pathptrn[0..node.len()]
+                .copy_from_slice(node.as_signed_bytes());
+        }
+    }
+
+    if unsafe { ioctl(file.as_raw_fd(), DEVFSIO_RAPPLY, &rule) } < 0 {
+        fehler::throw!(anyhow!(
+            "devfs rule: ioctl(DEVFSIO_RAPPLY) failed: {}",
+            StdError::last_os_error()
+        ))
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::mount::{mount, unmount};
+
+    struct MountedDirectory<'a> {
+        path: &'a Path,
+    }
+
+    impl<'a> MountedDirectory<'a> {
+        fn new(path: &'a Path) -> Self {
+            mount(&"devfs", &"devfs", &path, std::iter::empty())
+                .expect("failed to mount directory");
+
+            Self { path }
+        }
+    }
+
+    impl<'a> Drop for MountedDirectory<'a> {
+        fn drop(&mut self) {
+            unmount(&self.path)
+                .expect("failed to unmount directory");
+        }
+    }
+
+    #[test]
+    fn test_device_unhide() {
+        let tmpdir = tempfile::tempdir().unwrap();
+
+        let _directory = MountedDirectory::new(tmpdir.path());
+
+        assert!(
+            tmpdir.path().join("null").exists(),
+            "/dev/null must be present"
+        );
+
+        apply(tmpdir.path(), Operation::HideAll)
+            .expect("Failed to hide all nodes");
+
+        assert!(
+            !tmpdir.path().join("null").exists(),
+            "hide all hides /dev/null"
+        );
+
+        apply(tmpdir.path(), Operation::Unhide("null"))
+            .expect("Failed to unhide /dev/null");
+
+        assert!(
+            tmpdir.path().join("null").exists(),
+            "unhide(null) unhides /dev/null"
+        );
+    }
+}

--- a/knast/src/filesystem/mount.rs
+++ b/knast/src/filesystem/mount.rs
@@ -1,0 +1,104 @@
+/// Bindings around mount and umount(2) syscalls.
+use std::{convert::AsRef, io::Error as StdError, io::IoSlice, path::Path};
+
+use anyhow::{anyhow, Error};
+
+#[fehler::throws]
+pub fn mount<'a>(
+    kind: &dyn AsRef<Path>,
+    source: &dyn AsRef<Path>,
+    destination: &dyn AsRef<Path>,
+    options: impl Iterator<Item = &'a dyn AsRef<str>>,
+) {
+    let kind = kind.as_bytes()?;
+    let source = source.as_bytes()?;
+    let destination = destination.as_bytes()?;
+
+    let mut iovecs = vec![
+        IoSlice::new(b"fstype\0"),
+        IoSlice::new(kind.as_slice()),
+        IoSlice::new(b"fspath\0"),
+        IoSlice::new(destination.as_slice()),
+        IoSlice::new(b"from\0"),
+        IoSlice::new(source.as_slice()),
+        IoSlice::new(b"errmsg\0"),
+        IoSlice::new(&[0; 255]),
+    ];
+
+    for key in options {
+        for option in key.as_ref().split("=") {
+            iovecs.push(IoSlice::new(option.as_bytes()));
+        }
+    }
+
+    let slice = iovecs.as_slice();
+
+    if unsafe { libc::nmount(slice as *const _ as _, iovecs.len() as _, 0) }
+        < 0
+    {
+        fehler::throw!(anyhow!(
+            "mount: nmount failed: {}",
+            StdError::last_os_error()
+        ))
+    };
+}
+
+#[fehler::throws]
+pub fn unmount(destination: &dyn AsRef<Path>) {
+    if unsafe {
+        libc::unmount(destination.as_bytes()?.as_slice() as *const _ as _, 0)
+    } < 0
+    {
+        fehler::throw!(anyhow!(
+            "mount: unmount failed: {}",
+            StdError::last_os_error(),
+        ))
+    }
+}
+
+trait AsBytes {
+    #[fehler::throws]
+    fn as_bytes(&self) -> Vec<u8>;
+}
+
+impl AsBytes for &dyn AsRef<Path> {
+    // TODO: too complex. Is there a better way?
+    #[fehler::throws]
+    fn as_bytes(&self) -> Vec<u8> {
+        use std::{ffi::CString, ffi::OsStr, os::unix::ffi::OsStrExt};
+
+        let path: &Path = self.as_ref();
+        let os_str: &OsStr = path.as_ref();
+        CString::new(os_str.as_bytes())?.into_bytes_with_nul()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use super::*;
+
+    #[test]
+    fn test_mounting_nullfs() {
+        let source = tempfile::tempdir().unwrap();
+        let dest = tempfile::tempdir().unwrap();
+
+        mount(&"nullfs", &source.path(), &dest.path(), std::iter::empty())
+            .expect("failed to mount nullfs");
+
+        let mount_output = Command::new("mount")
+            .output()
+            .expect("Failed to execute mount");
+
+        let output_string = String::from_utf8(mount_output.stdout).unwrap();
+
+        assert!(output_string.contains(&format!(
+            "{} on {} (nullfs",
+            source.path().display(),
+            dest.path().display()
+        )));
+
+        unmount(&dest.path()).expect("failed to unmount nullfs");
+    }
+}

--- a/knast/src/filesystem/mount.rs~
+++ b/knast/src/filesystem/mount.rs~
@@ -1,0 +1,104 @@
+/// Bindings around mount and umount(2) syscalls.
+use std::{convert::AsRef, io::Error as StdError, io::IoSlice, path::Path};
+
+use anyhow::{anyhow, Error};
+
+#[fehler::throws]
+pub fn mount<'a>(
+    kind: &dyn AsRef<Path>,
+    source: &dyn AsRef<Path>,
+    target: &dyn AsRef<Path>,
+    options: impl Iterator<Item = &'a str>,
+) {
+    let kind = kind.as_bytes()?;
+    let source = source.as_bytes()?;
+    let target = target.as_bytes()?;
+
+    let mut iovecs = vec![
+        IoSlice::new(b"fstype\0"),
+        IoSlice::new(kind.as_slice()),
+        IoSlice::new(b"fspath\0"),
+        IoSlice::new(target.as_slice()),
+        IoSlice::new(b"from\0"),
+        IoSlice::new(source.as_slice()),
+        IoSlice::new(b"errmsg\0"),
+        IoSlice::new(&[0; 255]),
+    ];
+
+    for key in options {
+        for option in key.split("=") {
+            iovecs.push(IoSlice::new(option.as_bytes()));
+        }
+    }
+
+    let slice = iovecs.as_slice();
+
+    if unsafe { libc::nmount(slice as *const _ as _, iovecs.len() as _, 0) }
+        < 0
+    {
+        fehler::throw!(anyhow!(
+            "mount: nmount failed: {}",
+            StdError::last_os_error()
+        ))
+    };
+}
+
+#[fehler::throws]
+pub fn unmount(target: &dyn AsRef<Path>) {
+    if unsafe {
+        libc::unmount(target.as_bytes()?.as_slice() as *const _ as _, 0)
+    } < 0
+    {
+        fehler::throw!(anyhow!(
+            "mount: unmount failed: {}",
+            StdError::last_os_error(),
+        ))
+    }
+}
+
+trait AsBytes {
+    #[fehler::throws]
+    fn as_bytes(&self) -> Vec<u8>;
+}
+
+impl AsBytes for &dyn AsRef<Path> {
+    // TODO: too complex. Is there a better way?
+    #[fehler::throws]
+    fn as_bytes(&self) -> Vec<u8> {
+        use std::{ffi::CString, ffi::OsStr, os::unix::ffi::OsStrExt};
+
+        let path: &Path = self.as_ref();
+        let os_str: &OsStr = path.as_ref();
+        CString::new(os_str.as_bytes())?.into_bytes_with_nul()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use super::*;
+
+    #[test]
+    fn test_mounting_nullfs() {
+        let source = tempfile::tempdir().unwrap();
+        let dest = tempfile::tempdir().unwrap();
+
+        mount(&"nullfs", &source.path(), &dest.path(), std::iter::empty())
+            .expect("failed to mount nullfs");
+
+        let mount_output = Command::new("mount")
+            .output()
+            .expect("Failed to execute mount");
+
+        let output_string = String::from_utf8(mount_output.stdout).unwrap();
+
+        assert!(output_string.contains(&format!(
+            "{} on {} (nullfs",
+            source.path().display(),
+            dest.path().display()
+        )));
+
+        unmount(&dest.path()).expect("failed to unmount nullfs");
+    }
+}

--- a/knast/src/lib.rs
+++ b/knast/src/lib.rs
@@ -1,0 +1,2 @@
+mod filesystem;
+mod operations;

--- a/knast/src/operations.rs
+++ b/knast/src/operations.rs
@@ -1,0 +1,1 @@
+mod create;

--- a/knast/src/operations/create.rs
+++ b/knast/src/operations/create.rs
@@ -1,0 +1,17 @@
+use std::{convert::AsRef, fs::File, io::BufReader, path::Path};
+
+use anyhow::Error;
+use baustelle::runtime_config::RuntimeConfig;
+
+#[fehler::throws]
+pub fn perform(id: String, path: impl AsRef<Path>) {
+    let config = runtime_config(&path)?;
+}
+
+#[fehler::throws]
+fn runtime_config(path: impl AsRef<Path>) -> RuntimeConfig {
+    let config = File::open(path.as_ref().join("config.json"))?;
+    let reader = BufReader::new(config);
+
+    serde_json::from_reader(reader)?
+}

--- a/netzwerk/Cargo.toml
+++ b/netzwerk/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+common_lib = { path = "../common_lib" }
 fehler = { git = "https://github.com/withoutboats/fehler" }
 libc = "0.2.71"
 ipnetwork = "0.17.0"
@@ -16,4 +17,4 @@ bindgen = "0.57"
 [dev-dependencies]
 test_helpers = { path = "../test_helpers" }
 jail = { git = "https://github.com/fubarnetes/libjail-rs", branch = "dev" }
-nix = "0.17.0"
+nix = "0.20.0"

--- a/netzwerk/examples/bridge_jail.rs
+++ b/netzwerk/examples/bridge_jail.rs
@@ -51,7 +51,7 @@ fn main() {
     let name = create_interfaces()
         .expect("Failed to create interfaces");
 
-    match fork() {
+    match unsafe { fork() } {
         Ok(ForkResult::Child) => {
             if unsafe { jail_attach(JAIL_NUMBER) } < 0 {
                 panic!("Failed to attach to jail {}", JAIL_NUMBER);

--- a/netzwerk/src/pf.rs
+++ b/netzwerk/src/pf.rs
@@ -20,6 +20,7 @@ use bindings::{
     pfioc_trans_pfioc_trans_e, pfr_addr, pfr_table, PFI_AFLAG_NOALIAS,
     PFR_TFLAG_PERSIST, PF_ADDR_DYNIFTL, PF_NAT, PF_RULESET_NAT,
 };
+use common_lib::AsSignedBytes;
 use ipnetwork::Ipv4Network;
 use libc::{ioctl, AF_INET};
 
@@ -296,22 +297,6 @@ fn transaction_struct(
         },
         boxed_nat_request,
     )
-}
-
-trait AsSignedBytes {
-    fn as_signed_bytes(&self) -> &[i8] {
-        let bytes = unsafe { self.bytes().align_to() };
-
-        bytes.1
-    }
-
-    fn bytes(&self) -> &[u8];
-}
-
-impl AsSignedBytes for &str {
-    fn bytes(&self) -> &[u8] {
-        self.as_bytes()
-    }
 }
 
 #[cfg(test)]

--- a/test_helpers/procedural_macros/src/lib.rs
+++ b/test_helpers/procedural_macros/src/lib.rs
@@ -29,7 +29,7 @@ pub fn jailed_test(_attrs: TokenStream, item: TokenStream) -> TokenStream {
             .start()
             .expect("Couldn't start jail");
 
-        match fork() {
+        match unsafe { fork() } {
             Ok(ForkResult::Child) => {
                 jail.attach().unwrap();
                 let result = std::panic::catch_unwind(|| {


### PR DESCRIPTION
During OCI runtime creation, we need to mount directories, in
particular /dev. However, giving the container access to all device
nodes is dangerous. The idiomatic tool for this is devfs control
facilities, which allows us to dynamically hide & unhide device nodes
from the mounted subsystem.

This change
* adds bindings to replicate what devfs(8) does.
* adds a mountable trait, implements the trait for runtime configs
  `Mount` type